### PR TITLE
fix: make remove_reply_to_user_id migration idempotent

### DIFF
--- a/alembic/versions/b1c2d3e4f5a6_remove_reply_to_user_id.py
+++ b/alembic/versions/b1c2d3e4f5a6_remove_reply_to_user_id.py
@@ -9,6 +9,7 @@ Create Date: 2026-03-27 00:00:00.000000
 from typing import Sequence, Union
 
 import sqlalchemy as sa
+from sqlalchemy import inspect
 
 from alembic import op
 
@@ -20,11 +21,18 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.drop_index(
-        op.f("ix_thread_comments_reply_to_user_id"),
-        table_name="thread_comments",
-    )
-    op.drop_column("thread_comments", "reply_to_user_id")
+    conn = op.get_bind()
+    inspector = inspect(conn)
+    columns = [c["name"] for c in inspector.get_columns("thread_comments")]
+
+    if "reply_to_user_id" in columns:
+        indexes = [idx["name"] for idx in inspector.get_indexes("thread_comments")]
+        if "ix_thread_comments_reply_to_user_id" in indexes:
+            op.drop_index(
+                op.f("ix_thread_comments_reply_to_user_id"),
+                table_name="thread_comments",
+            )
+        op.drop_column("thread_comments", "reply_to_user_id")
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary
- Check if `reply_to_user_id` column and its index exist before attempting to drop them in migration `b1c2d3e4f5a6`
- Fixes deploy boot loop caused by the migration crashing repeatedly

## Root Cause
`Base.metadata.create_all()` had previously created `thread_comments` directly from ORM models (without `reply_to_user_id`). When migration `a93158ec4674` ran, its `if "thread_comments" not in tables` guard skipped table creation entirely -- so the column and index were never added. Migration `b1c2d3e4f5a6` then crashed trying to drop non-existent objects.

## Test plan
- [ ] Deploy succeeds without boot loop
- [ ] Migration is a no-op when column doesn't exist
- [ ] Migration correctly drops column when it does exist

Generated with [Claude Code](https://claude.com/claude-code)